### PR TITLE
Placeholder warnings

### DIFF
--- a/default-config.yaml
+++ b/default-config.yaml
@@ -1,3 +1,8 @@
+# saf2isatab.pl will die if any of these strings are in the config or data files
+# apart from in `placeholder_strings` sections of course
+placeholder_strings:
+  - PLACEHOLDER
+  - XXX
 
 columns:
   location_ID:


### PR DESCRIPTION
Request from @samrund 

If the config or data files contain some predefined strings (defaults are "XXX" and "PLACEHOLDER") then the ISA-Tab generation should fail or warn.

Matching is case sensitive.

User can configure new placeholder strings (will overwrite the defaults above) in their config file (see below). Note that the definition itself won't trigger a warning - as that would be ridiculous.

```
placeholder_strings:
  - TEMP
  - TO DO
  - FIXME
```


The result is a bunch of extra warnings:

```
Cannot proceed with writing ISA-Tab due to the following data errors:

 placeholder string 'PLACEHOLDER' was found in your config file
 placeholder string 'XXX' was found in your config file
 protocol ref 'COLLECT' not found in study_protocols
 value 'shannon' not found in 'study_terms' term lookup
 value 'hay' not found in 'study_terms' term lookup
 value 'CO2' not found in 'study_terms' term lookup
 placeholder string 'XXX' was found in a row of your data file ({"location_ID":"myplace01","collection_ID":"mycollection01","sample_ID":"mysample02"})
```