### PR TITLE
Add units capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ deprecated | | "deprecation message" | Optional | Used to deprecated SAF1.0 buil
 multivalued | `false` | `true`, `false` | Optional |
 delimiter | ; |  | Optional | character used to delimit multiple values (white-space before and after will be ignored)
 term_lookup | `study_terms` | `study_terms`, `study_sexes`, `study_species`, `study_developmental_stages` | Optional | name of lookup section in config file if the column is `value_type: term`.
+unit | | name of the unit, e.g. 'percent' | Optional | Make sure to provide the `unit_term` also if using this. Note: this is a dataset-wide configuration for the column. Units must be the same for the entire column.
+unit_term | | accession of the unit, e.g. 'UO_0000187' | Human-readable `unit` *must* also be provided if using the term accession.
 ignore | `false` | `true`, `false` | Optional | This will allow an input column to be silently ignored. Even if it is a required column. Your mileage may vary. Do not ignore ID columns!
 
 See [default-column-config.yaml](default-column-config.yaml) for the built-in column definitions

--- a/saf2isatab.pl
+++ b/saf2isatab.pl
@@ -234,6 +234,15 @@ sub add_column_data {
 	  # not very efficient with the grep but 'allowed_values' will typically be small
 	}
 
+	# now handle units, if provided
+	if ($col_config->{unit}) {
+	  $characteristics->{unit}{value} = $col_config->{unit};
+	  if ($col_config->{unit_term}) {
+	    $characteristics->{unit}{term_source_ref} = 'TERM';
+	    $characteristics->{unit}{term_accession_number} = $col_config->{unit_term};
+	  }
+	}
+
 	# ontology term values require a lookup from text to term:
       } elsif ($col_config->{value_type} eq 'term') {
 	# get the lookup hash (already validated - no need to check success)

--- a/saf2isatab.pl
+++ b/saf2isatab.pl
@@ -421,6 +421,15 @@ sub validate_config {
   die "FATAL ERROR: these columns contain `protocol` values that are not in study_protocols: ".join(', ', @awful)."\n"
     if (@awful);
 
+  # check that any column with `unit` annotation also has `value_type: number`
+  my @unfortunate = grep {
+    !$column_config->{$_}{ignore} &&
+    $column_config->{$_}{unit} &&
+    $column_config->{$_}{value_type} ne 'number'
+  }  keys %$column_config;
+  die "FATAL ERROR: these columns have units but are not number columns: ".join(', ', @unfortunate)."\n"
+    if (@unfortunate);
+
   ### the following have side effects!
 
   # add the default `required: true` to any column that doesn't have it

--- a/test-config.yaml
+++ b/test-config.yaml
@@ -53,6 +53,16 @@ columns:
   junk:
     ignore: true
 
+# units testing
+
+  measurement:
+    value_type: number
+    describes: sample
+    column_term: APOLLO_SV_00000445
+    unit: percent
+    unit_term: UO_0000187
+    description: some measurement reported as a percentage
+
 study_protocols:
   - study_protocol_name : COLLECT
     study_protocol_type : citizen science collection

--- a/test-saf2.tsv
+++ b/test-saf2.tsv
@@ -1,3 +1,3 @@
-location_ID	collection_ID	sample_ID	junk	collection_method	collection_start_date	collection_end_date	collection_device	attractant	collection_comment	GPS_latitude	GPS_longitude	species	species_identification_method	sample_comment	pathogen_status_Pf	pathogen_status_Pv
-myplace01	mycollection01	mysample01	rubbish	COLLECT	2002-02-02	2002-02-03	shannon	hay;CO2	cool collection	12.34	9.87	Anopheles darlingi	PCR	amazing sample	present	absent
-myplace01	mycollection01	mysample02	trash	COLLECT	2002-02-02	2002-02-03	shannon	hay;CO2	cool collection	12.34	9.87	Anopheles albimanus	PCR	super sample	absent	present
+location_ID	collection_ID	sample_ID	junk	collection_method	collection_start_date	collection_end_date	collection_device	attractant	collection_comment	GPS_latitude	GPS_longitude	species	species_identification_method	sample_comment	pathogen_status_Pf	pathogen_status_Pv	measurement
+myplace01	mycollection01	mysample01	rubbish	COLLECT	2002-02-02	2002-02-03	shannon	hay;CO2	cool collection	12.34	9.87	Anopheles darlingi	PCR	amazing sample	present	absent	42
+myplace01	mycollection01	mysample02	trash	COLLECT	2002-02-02	2002-02-03	shannon	hay;CO2	cool collection	12.34	9.87	Anopheles albimanus	PCR	super sample	absent	present	99


### PR DESCRIPTION
Number columns can now have dataset-wide units specified for them.

```
  some_measurement:
    value_type: number
    describes: sample
    column_term: APOLLO_SV_00000445
    unit: percent
    unit_term: UO_0000187
    description: some measurement reported as a percentage
```