### PR TITLE
Handle empty assays properly and avoid orphan units

### DIFF
--- a/saf2isatab.pl
+++ b/saf2isatab.pl
@@ -586,12 +586,12 @@ sub make_auto_entity_id {
 
   return '' if ($signature =~ /^:*$/); # if all the columns were empty the signature will be empty or just colons
 
-  if (!$seen_signatures{$signature}) {
-    my $new_id = sprintf '%s-%05d', $entity->{name}, 1 + keys %seen_signatures;
+  if (!$seen_signatures{$entity->{name}}{$signature}) {
+    my $new_id = sprintf '%s-%05d', $entity->{name}, 1 + keys %{$seen_signatures{$entity->{name}}};
     $new_id =~ s/ /_/g; # change spaces to underscores
-    $seen_signatures{$signature} = $new_id;
+    $seen_signatures{$entity->{name}}{$signature} = $new_id;
   }
-  return $seen_signatures{$signature};
+  return $seen_signatures{$entity->{name}}{$signature};
 }
 
 

--- a/saf2isatab.pl
+++ b/saf2isatab.pl
@@ -329,19 +329,19 @@ sub add_assay {
     my $assay_filename = make_assay_filename($study_assay_measurement_type, $row_protocol_ref, $column_protocol_ref);
     my $study_assay = find_or_create_study_assay($config_and_study, $study_assay_measurement_type, $assay_filename);
 
+    # make an assay ID - which will be '' if there is no data for the assay
     my $assay_id = make_auto_entity_id($entity, $row, $column_keys, $config_and_study);
 
-    # now add the link sample and assay
-    my $assay = $study_assay->{samples}{$row->{sample_ID}}{assays}{$assay_id} //= {};
+    if ($assay_id) {
+      # now add the link sample and assay
+      my $assay = $study_assay->{samples}{$row->{sample_ID}}{assays}{$assay_id} //= {};
 
-    # add the column-wise protocol ref explicitly
-    $assay->{protocols}{$column_protocol_ref} = {}
-      if ($column_protocol_ref);
-    # otherwise row-wise protocol ref will be added from the input $row by add_column_data
-    add_column_data($assay, $column_keys, $row, $entity, $config_and_study);
-    # if nothing was added in addition to the protocols, delete the assay node
-    my @assay_keys = keys %{$assay};
-    delete $study_assay->{samples}{$row->{sample_ID}}{assays}{$assay_id} unless (grep {$_ ne 'protocols'} @assay_keys);
+      # add the column-wise protocol ref explicitly
+      $assay->{protocols}{$column_protocol_ref} = {}
+	if ($column_protocol_ref);
+      # otherwise row-wise protocol ref will be added from the input $row by add_column_data
+      add_column_data($assay, $column_keys, $row, $entity, $config_and_study);
+    }
   }
 }
 


### PR DESCRIPTION
Not all samples have assays. Here we take care of that.

We also prevent units columns being generated when there are no corresponding values.